### PR TITLE
Add support for batch document insertion to YDB

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   ydb:
-    image: ydbplatform/local-ydb:trunk
+    image: ydbplatform/local-ydb:24.3.13.12
     restart: always
     ports:
       - "2136:2136"

--- a/tests/test_vectorestore.py
+++ b/tests/test_vectorestore.py
@@ -16,7 +16,7 @@ def test_ydb() -> None:
     docsearch = YDB.from_texts(texts, ConsistentFakeEmbeddings(), config=config)
     output = docsearch.similarity_search("foo", k=1)
     assert output == [Document(page_content="foo")]
-    # docsearch.drop()
+    docsearch.drop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR adds support for batch insertion of documents in the ydb-langchain integration project. Previously, documents were embedded and uploaded one at a time, which was inefficient for larger datasets.

Now, using structs/lists, multiple documents can be embedded and inserted into YDB in a single request, significantly improving performance and reducing overhead.