### PR TITLE
Add get_by_ids() / aget_by_ids() to YDB and AsyncYDB vector stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,4 @@
-## Unreleased ##
 * Add `get_by_ids()` / `aget_by_ids()` to `YDB` & `AsyncYDB` vector stores
-  (parameterized `IN $ids`, input order preserved, duplicate ids collapsed,
-  missing ids skipped). Unblocks mem0's get/update/delete over the YDB store.
 
 ## 0.0.16 ##
 * Make texts optional in add_embeddings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased ##
+* Add `get_by_ids()` / `aget_by_ids()` to `YDB` & `AsyncYDB` vector stores
+  (parameterized `IN $ids`, input order preserved, duplicate ids collapsed,
+  missing ids skipped). Unblocks mem0's get/update/delete over the YDB store.
+
 ## 0.0.16 ##
 * Make texts optional in add_embeddings
 

--- a/langchain_ydb/vectorstores.py
+++ b/langchain_ydb/vectorstores.py
@@ -401,9 +401,12 @@ class _YDBStoreBase:
             for row in res
         }
         seen: set[str] = set()
-        return [
-            by_id[i] for i in id_list if i in by_id and not (i in seen or seen.add(i))
-        ]
+        docs: list[Document] = []
+        for i in id_list:
+            if i in by_id and i not in seen:
+                seen.add(i)
+                docs.append(by_id[i])
+        return docs
 
 
 class YDB(_YDBStoreBase, VectorStore):

--- a/langchain_ydb/vectorstores.py
+++ b/langchain_ydb/vectorstores.py
@@ -6,7 +6,7 @@ import logging
 import struct
 from dataclasses import dataclass, field
 from hashlib import sha1
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
 
 import ydb
 import ydb_dbapi
@@ -372,6 +372,39 @@ class _YDBStoreBase:
             query += f" WHERE {self.config.column_map['id']} IN {str(ids)}"
         return query
 
+    def _prepare_get_by_ids_query(self) -> str:
+        cols = self.config.column_map
+        return f"""
+        DECLARE $ids AS List<Utf8>;
+        SELECT
+            {cols["id"]} as id,
+            {cols["document"]} as document,
+            {cols["metadata"]} as metadata
+        FROM {self.config.table}
+        WHERE {cols["id"]} IN $ids;
+        """
+
+    @staticmethod
+    def _get_by_ids_params(ids: Sequence[str]) -> tuple[list[str], dict]:
+        # Pass ids as a server-side List<Utf8> parameter (never string-interpolated),
+        # so an id containing a quote cannot break out of the query.
+        id_list = [str(i) for i in ids]
+        return id_list, {"$ids": (id_list, ydb.ListType(ydb.PrimitiveType.Utf8))}
+
+    def _docs_by_input_order(self, res: list, id_list: list[str]) -> list[Document]:
+        by_id = {
+            row["id"]: Document(
+                page_content=row["document"],
+                metadata=self._parse_metadata(row["metadata"]),
+                id=row["id"],
+            )
+            for row in res
+        }
+        seen: set[str] = set()
+        return [
+            by_id[i] for i in id_list if i in by_id and not (i in seen or seen.add(i))
+        ]
+
 
 class YDB(_YDBStoreBase, VectorStore):
     """Synchronous YDB vector store (``ydb-dbapi`` + sync driver).
@@ -710,6 +743,18 @@ class YDB(_YDBStoreBase, VectorStore):
         query = self._prepare_delete_query(ids)
         self._execute_query(query)
         return True
+
+    def get_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        """Get documents by their ids.
+
+        Returns a document for each id that exists; ids that are not found are
+        skipped, and a repeated id yields at most one document.
+        """
+        if not ids:
+            return []
+        id_list, params = self._get_by_ids_params(ids)
+        res = self._execute_query(self._prepare_get_by_ids_query(), params=params)
+        return self._docs_by_input_order(res, id_list)
 
     def similarity_search(
         self, query: str, k: int = 4, filter: Optional[dict] = None, **kwargs: Any
@@ -1168,6 +1213,9 @@ class AsyncYDB(_YDBStoreBase, VectorStore):
     def delete(self, ids: Optional[list[str]] = None, **kwargs: Any) -> Optional[bool]:
         raise NotImplementedError(_ASYNCYDB_SYNC_MSG)
 
+    def get_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        raise NotImplementedError(_ASYNCYDB_SYNC_MSG)
+
     def drop(self) -> None:
         raise NotImplementedError(_ASYNCYDB_SYNC_MSG)
 
@@ -1177,6 +1225,16 @@ class AsyncYDB(_YDBStoreBase, VectorStore):
         query = self._prepare_delete_query(ids)
         await self._execute_query_async(query)
         return True
+
+    async def aget_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        """Get documents by their ids (async). See ``YDB.get_by_ids``."""
+        if not ids:
+            return []
+        id_list, params = self._get_by_ids_params(ids)
+        res = await self._execute_query_async(
+            self._prepare_get_by_ids_query(), params=params
+        )
+        return self._docs_by_input_order(res, id_list)
 
     async def asimilarity_search(
         self,

--- a/tests/test_vectorestore.py
+++ b/tests/test_vectorestore.py
@@ -75,7 +75,7 @@ class TestYDBVectorStore:
         docsearch.drop()
 
     def test_get_by_ids(self) -> None:
-        """get_by_ids: returns docs by id, in input order, dups collapsed, missing skipped."""
+        """get_by_ids: docs by id, input order kept, dups collapsed, missing skipped."""
         config = YDBSettings(drop_existing_table=True)
         config.table = "test_ydb_get_by_ids"
         docsearch = YDB.from_texts(
@@ -86,8 +86,11 @@ class TestYDBVectorStore:
         )
         try:
             got = docsearch.get_by_ids(["id-c", "id-a", "id-c", "missing"])
-            assert [d.id for d in got] == ["id-c", "id-a"]  # order kept, dup→1, missing skipped
-            assert document_eq(got[0], Document(page_content="gamma"), check_id=True)
+            # order kept, dup collapsed to one, missing skipped
+            assert [d.id for d in got] == ["id-c", "id-a"]
+            assert document_eq(
+                got[0], Document(page_content="gamma", id="id-c"), check_id=True
+            )
             assert docsearch.get_by_ids([]) == []
         finally:
             docsearch.drop()

--- a/tests/test_vectorestore.py
+++ b/tests/test_vectorestore.py
@@ -74,6 +74,43 @@ class TestYDBVectorStore:
         assert document_eq(output[0], Document(page_content="foo"))
         docsearch.drop()
 
+    def test_get_by_ids(self) -> None:
+        """get_by_ids: returns docs by id, in input order, dups collapsed, missing skipped."""
+        config = YDBSettings(drop_existing_table=True)
+        config.table = "test_ydb_get_by_ids"
+        docsearch = YDB.from_texts(
+            ["alpha", "beta", "gamma"],
+            ConsistentFakeEmbeddings(),
+            config=config,
+            ids=["id-a", "id-b", "id-c"],
+        )
+        try:
+            got = docsearch.get_by_ids(["id-c", "id-a", "id-c", "missing"])
+            assert [d.id for d in got] == ["id-c", "id-a"]  # order kept, dup→1, missing skipped
+            assert document_eq(got[0], Document(page_content="gamma"), check_id=True)
+            assert docsearch.get_by_ids([]) == []
+        finally:
+            docsearch.drop()
+
+    @pytest.mark.asyncio
+    async def test_aget_by_ids(self) -> None:
+        """aget_by_ids mirrors get_by_ids on AsyncYDB."""
+        config = YDBSettings(drop_existing_table=True)
+        config.table = "test_ydb_aget_by_ids"
+        store = await AsyncYDB.afrom_texts(
+            ["alpha", "beta", "gamma"],
+            ConsistentFakeEmbeddings(),
+            config=config,
+            ids=["id-a", "id-b", "id-c"],
+        )
+        try:
+            got = await store.aget_by_ids(["id-c", "id-a", "id-c", "missing"])
+            assert [d.id for d in got] == ["id-c", "id-a"]
+            assert await store.aget_by_ids([]) == []
+        finally:
+            await store.adrop()
+            await store.aclose()
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize("vector_pass_as_bytes", [True, False])
     async def test_asimilarity_search_uses_executor(


### PR DESCRIPTION
## What

Implements `get_by_ids()` on `YDB` and `aget_by_ids()` on `AsyncYDB`. The base
`VectorStore.get_by_ids` raises `NotImplementedError("YDB does not yet support
get_by_ids.")`; `delete(ids)` is already implemented, so only fetch-by-id was missing.

## Why

Consumers such as [mem0](https://github.com/mem0ai/mem0) call
`vector_store.get_by_ids(...)` before `get`/`update`/`delete`. Without it those
operations fail against the YDB store. This single method unblocks full CRUD over the
YDB vector store.

## How

- Parameterized `IN $ids` (`DECLARE $ids AS List<Utf8>`) — values are passed
  server-side, never string-interpolated (escape-safe; stricter than the existing
  `_prepare_delete_query`).
- Returns documents in input order; duplicate ids collapse to one; missing ids are
  skipped — per LangChain's `get_by_ids` contract.
- `ids` is positional-only to match the base signature.
- Sync `YDB.get_by_ids` + async `AsyncYDB.aget_by_ids`; the sync method on `AsyncYDB`
  raises `_ASYNCYDB_SYNC_MSG` like the other sync methods. Shared query/param/assembly
  helpers live on `_YDBStoreBase`.
- Tests in `tests/test_vectorestore.py` (`test_get_by_ids`, `test_aget_by_ids`) +
  CHANGELOG entry.

Behavior was verified live against a Serverless YDB (sync + async: input order, dedup,
skip-missing, empty input, metadata round-trip, reflects `delete`). Opened as draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
